### PR TITLE
ci: update action packages, support linux aarch64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,7 @@ jobs:
           name: wheels
 
       - name: Python setup
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        target: [x86_64, i686]
+        target: [x86_64, i686, aarch64]
     steps:
     - name: Checkout project
       uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,20 +14,16 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Python setup
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64
-  
+
       - name: Rust setup
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build wheels - x86_64
         uses: PyO3/maturin-action@v1
@@ -44,7 +40,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           args: --release --universal2 --out dist
-  
+
       - name: Install built wheel - universal2
         run: |
           pip install akatsuki_pp_py --no-index --find-links dist --force-reinstall
@@ -64,7 +60,7 @@ jobs:
         target: [x64, x86]
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Python setup
         uses: actions/setup-python@v4
@@ -73,11 +69,7 @@ jobs:
           architecture: ${{ matrix.target }}
 
       - name: Rust setup
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -104,8 +96,8 @@ jobs:
         target: [x86_64, i686, aarch64]
     steps:
     - name: Checkout project
-      uses: actions/checkout@v3
-    
+      uses: actions/checkout@v4
+
     - name: Python setup
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
now uses dtolnay/rust-toolchain, action-rs seems [unmaintained](https://github.com/actions-rs/toolchain/issues/216)

linux py3.9 aarch64 has tested on ubuntu 22.04, and works!