### PR TITLE
allow unexpected cfgs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 #![deny(clippy::all, nonstandard_style, rust_2018_idioms, unused, warnings)]
 
 use self::{


### PR DESCRIPTION
resolves complaints about pyo3's `Py_LIMITED_API` config directive